### PR TITLE
Update JDK and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+.idea/
+*.iml

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,8 +2,8 @@
 <go-plugin id="s3-poller" version="1">
     <about>
         <name>S3 Poller</name>
-        <version>1.0.0</version>
-        <target-go-version>14.4.0</target-go-version>
+        <version>1.1.0</version>
+        <target-go-version>20.3.0</target-go-version>
         <description>Plugin that polls a S3 Bucket</description>
         <vendor>
             <name>Schibsted Products and Technology</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,18 +6,29 @@
 
     <groupId>com.schibsted</groupId>
     <artifactId>gocd-s3-poller</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <go.version>15.1.0</go.version>
+        <go.version>20.3.0</go.version>
         <main.dir>${project.basedir}</main.dir>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bom</artifactId>
+                <version>1.11.782</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>cd.go.plugin</groupId>
             <artifactId>go-plugin-api</artifactId>
-            <version>15.1.0</version>
+            <version>20.3.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -27,8 +38,7 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <version>1.10.2</version>
+            <artifactId>aws-java-sdk-s3</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -49,16 +59,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.5</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>13</source>
+                    <target>13</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -71,7 +81,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>copy-plugin-jars-to-dist</id>
@@ -94,7 +104,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.10</version>
+                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>


### PR DESCRIPTION
The plugin does not work on the latest GoCD docker image.  This was due to an old version of the AWS SDK old version that relied on jaxb.  This updates to the latest version of the AWS SDK to fix.